### PR TITLE
Here's the rewritten message:

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -11,17 +11,45 @@ echo "Installing Homebrew"
 
 # Setup homebrew
 echo "Getting ready"
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/scripts/homebrew-setup.sh)"
+echo "Attempting to download and execute setup script from: https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/scripts/homebrew-setup.sh"
+homebrew_setup_script_content=$(curl -fsSL https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/scripts/homebrew-setup.sh)
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to download Homebrew setup script."
+  exit 1
+fi
+if [ -z "$homebrew_setup_script_content" ] || echo "$homebrew_setup_script_content" | grep -q "DOCTYPE html" || echo "$homebrew_setup_script_content" | grep -q "404 Not Found"; then
+  echo "Error: Invalid content received for Homebrew setup script."
+  exit 1
+fi
+/bin/bash -c "$homebrew_setup_script_content"
 
 # Install Apps
 echo "Installing apps"
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/personal-files/$USERNAME/homebrew-install-apps.sh)"
+USER_SCRIPT_URL="https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/personal-files/$USERNAME/homebrew-install-apps.sh"
+echo "Checking if user-specific script exists at: $USER_SCRIPT_URL"
+if ! curl --head --silent --fail -L "$USER_SCRIPT_URL" > /dev/null; then
+  echo "Error: User-specific script not found at $USER_SCRIPT_URL. Please ensure the username '$USERNAME' is correct and the corresponding script exists in the remote repository."
+  exit 1
+fi
+echo "Attempting to download and execute user-specific apps script from: $USER_SCRIPT_URL"
+homebrew_install_apps_script_content=$(curl -fsSL "$USER_SCRIPT_URL")
+if [ $? -ne 0 ]; then
+  echo "Error: Failed to download Homebrew install apps script."
+  exit 1
+fi
+if [ -z "$homebrew_install_apps_script_content" ] || echo "$homebrew_install_apps_script_content" | grep -q "DOCTYPE html" || echo "$homebrew_install_apps_script_content" | grep -q "404 Not Found"; then
+  echo "Error: Invalid content received for Homebrew install apps script."
+  exit 1
+fi
+/bin/bash -c "$homebrew_install_apps_script_content"
 
+# The following section for the OpenCore Legacy Patcher is currently disabled.
+# It can be enabled if you are running this script on a Mac with an unsupported macOS version.
 # Legacy Mac Patcher
 #read -r -p "Is this Mac running an unsupported version of macOS? [Y/n] " input
 # case $input in
 #    [yY][eE][sS]|[yY])
-#        /bin/bash -c "$(curl -fsSL /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/scripts/opencore-legacy-install.sh)"
+#        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/scripts/opencore-legacy-install.sh)"
 # ;;
 #    [nN][oO]|[nN])
 #  echo "Skipping..."
@@ -36,7 +64,17 @@ echo "Installing apps"
 read -r -p "Do you want to install Office Apps? [Y/n] " input
  case $input in
     [yY][eE][sS]|[yY])
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/scripts/office-install.sh)"
+        echo "Attempting to download and execute Office installation script from: https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/scripts/office-install.sh"
+        office_install_script_content=$(curl -fsSL https://raw.githubusercontent.com/lovozeto/macOS-postinstall/master/scripts/office-install.sh)
+        if [ $? -ne 0 ]; then
+          echo "Error: Failed to download Office install script."
+          exit 1
+        fi
+        if [ -z "$office_install_script_content" ] || echo "$office_install_script_content" | grep -q "DOCTYPE html" || echo "$office_install_script_content" | grep -q "404 Not Found"; then
+          echo "Error: Invalid content received for Office install script."
+          exit 1
+        fi
+        /bin/bash -c "$office_install_script_content"
  ;;
     [nN][oO]|[nN])
   echo "Skipping..."

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,12 @@ Special thanks to @andrewconnell and his amazong original repo:
   ```console
 https://github.com/andrewconnell
   ```
+
+## Important Notes on `installer.sh`
+
+*   **Remote Repository Dependence:** `installer.sh` fetches several helper scripts (like `homebrew-setup.sh`, user-specific app lists, and `office-install.sh`) directly from the `https://github.com/lovozeto/macOS-postinstall` repository. This means an active internet connection is required, and the script's successful execution depends on the availability and structure of that remote repository.
+*   **User-Specific Scripts:** When prompted for a name (`USERNAME`), you must provide a name for which a corresponding `personal-files/USERNAME/homebrew-install-apps.sh` script exists in the `lovozeto/macOS-postinstall` remote repository. If this script doesn't exist at that location, the "Install Apps" step will fail.
+*   **Troubleshooting Download Failures:** If the script fails with messages related to "Failed to download" or "script not found," you should:
+    *   Check your internet connection.
+    *   Verify the URL printed by the script in a web browser to see if it's accessible.
+    *   Ensure the `USERNAME` provided matches a configuration in the remote repository.


### PR DESCRIPTION
Improve installer.sh robustness and documentation

This commit introduces several enhancements to installer.sh:

- Adds robust error handling for remote script fetching (homebrew-setup.sh, user-specific homebrew-install-apps.sh, office-install.sh). This includes checking curl's exit status and inspecting fetched content for common error indicators (e.g., HTML error pages).
- Implements a pre-check for the user-specific script URL to validate its existence before attempting to download and execute, providing clearer error messages if the script is not found.
- Corrects a syntax error in the commented-out Legacy Mac Patcher command.
- Adds more informative echo messages throughout the script to indicate which remote resources are being accessed.

Additionally, the readme.md has been updated to include:
- An explanation of the script's reliance on the lovozeto/macOS-postinstall GitHub repository.
- Clarification on the importance of the USERNAME variable for fetching your user-specific configurations.
- Basic troubleshooting tips for download failures.

These changes aim to make the script more reliable and user-friendly, especially when you are diagnosing issues related to its remote execution model.